### PR TITLE
Udpate/customise std error rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,15 @@ Where forward strand primers have the character `F` as the final character, and 
 
 `-o <output_prefix>`: the prefix to be used on output files.
 
-`--merged`: this optional flag should be used when dealing with either **merged paired-end reads**, or **single-end reads**, so that PIMENTO can correctly identify reverse-orientation primers
+`-m <minimum_primer_threshold>`: this optional parameter sets the minimum proportion of reads a standard primer has to be present in to be considered in inference. Default value of 0.60 (60%) of reads.
+
+`-l <std_primer_read_prefix_length>`: this optional parameter sets the read prefix window length that is read for inferring the presence of standard primers. Default value of 50 bases.
+
+`-c <max_read_count>`: this optional parameter sets the maximum number of reads used to infer the presence of standard primers, to increase speed. Default value of 300,000 reads.
+
+`-e <std_primer_error_rate>`: this optional parameter sets the maximum error rate allowed for standard primers to be considered a match. A mismatch for an ambiguous base is counted as an error only if it doesn't match any of its possible bases. The number of bases always rounds up, e.g. primer lengths of 15 and 20 with an error rate of 0.1 will be a maximum of 2 errors for both primers. Default value of 0.1 (10%) of a primer's length in bases.
+
+`--merged`: this optional flag should be used when dealing with either **merged paired-end reads**, or **single-end reads**, so that PIMENTO can correctly identify reverse-orientation primers.
 
 `-t <threads>`: this optional parameter allows you to specify the number of threads to be used for the search. Default of 1.
 
@@ -101,6 +109,8 @@ NB: Running `pimento auto` executes the three subcommands `generate_bcv`, `find_
 `-i <fastq/fastq.gz>`: the input FASTQ reads file.
 
 `-st [FR/F/R]`: the selection of strands to perform primer inference for - F for forward, R for reverse, FR for both.
+
+`-c <max_read_count>`: this optional parameter sets the maximum number of reads used to infer the presence of standard primers, to increase speed. Default value of 300,000 reads.
 
 `-o <output_prefix>`: the prefix to be used on output files.
 

--- a/pimento/bin/pimento_utils.py
+++ b/pimento/bin/pimento_utils.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from collections import defaultdict, Counter
+from math import ceil
 from pathlib import Path
 import logging
 import pyfastx
@@ -152,7 +153,7 @@ def compute_windowed_base_conservation(
     return base_conservation, cons_seq
 
 
-def primer_regex_query_builder(primer):
+def primer_regex_query_builder(primer, std_primer_error_rate):
     """
     Takes an input nucleotide sequence that can contain IUPAC ambiguous codes
     Returns a string formatted as a regex query that considers the different
@@ -165,6 +166,8 @@ def primer_regex_query_builder(primer):
     """
 
     query = ""
+    primer_length = len(primer)
+    max_error = ceil(primer_length * std_primer_error_rate)
 
     for char in primer:
         if char in ("A", "C", "T", "G"):
@@ -172,7 +175,7 @@ def primer_regex_query_builder(primer):
         else:
             query += str(AMBIGUOUS_BASES_DICT[char])
 
-    query = f"(.*{query}){{e<=2}}"
+    query = f"(.*{query}){{e<={max_error}}}"
 
     return query
 

--- a/pimento/bin/pimento_utils.py
+++ b/pimento/bin/pimento_utils.py
@@ -153,7 +153,7 @@ def compute_windowed_base_conservation(
     return base_conservation, cons_seq
 
 
-def primer_regex_query_builder(primer, std_primer_error_rate):
+def primer_regex_query_builder(primer: str, std_primer_error_rate: float):
     """
     Takes an input nucleotide sequence that can contain IUPAC ambiguous codes
     Returns a string formatted as a regex query that considers the different
@@ -161,6 +161,8 @@ def primer_regex_query_builder(primer, std_primer_error_rate):
 
     :param primer: Nucleotide sequence string that may contain IUPAC ambiguity codes.
     :type primer: str
+    :param std_primer_error_rate: The maximum error rate allowed for standard primers.
+    :type std_primer_error_rate: float
     :return: Regex query string with ambiguity codes converted to character classes.
     :rtype: str
     """

--- a/pimento/bin/standard_primer_matching.py
+++ b/pimento/bin/standard_primer_matching.py
@@ -37,6 +37,7 @@ logger.setLevel(logging.INFO)
 
 def parse_std_primers(
     primers_dir: Path,
+    std_primer_error_rate: float,
     merged: bool = False,
 ) -> tuple[defaultdict[defaultdict], defaultdict[defaultdict]]:
     """
@@ -70,7 +71,7 @@ def parse_std_primers(
             if merged and primer_name[-1] == "R":
                 primer_seq = str(Seq(primer_seq).complement())
 
-            primer_regex = primer_regex_query_builder(primer_seq)
+            primer_regex = primer_regex_query_builder(primer_seq, std_primer_error_rate)
             std_primer_dict_regex[region][primer_name] = primer_regex
             std_primer_dict[region][primer_name] = primer_seq
             primer_count += 1

--- a/pimento/bin/standard_primer_matching.py
+++ b/pimento/bin/standard_primer_matching.py
@@ -48,6 +48,8 @@ def parse_std_primers(
 
     :param primers_dir: Path to directory containing standard primer FASTA files.
     :type primers_dir: Path
+    :param std_primer_error_rate: The maximum error rate allowed for standard primers.
+    :type std_primer_error_rate: float
     :param merged: Whether sequences are merged paired-end or single-end. Affects reverse primer handling.
         Defaults to False.
     :type merged: bool
@@ -86,6 +88,13 @@ def run_primer_matching_once(input_primer: str, substring_count_dict: dict):
     Takes one primer and a dictionary of read substrings and their counts.
     Uses fuzzy matching to allow for at most one error (for sequencing errors).
     Returns number of reads matching given primer.
+
+    :param input_primer: The primer sequence to match.
+    :type input_primer: str
+    :param substring_count_dict: Dictionary mapping substrings to their occurrence counts.
+    :type substring_count_dict: dict
+    :return: The total count of matching reads.
+    :rtype: float
     """
 
     match_count = 0.0
@@ -287,6 +296,17 @@ def write_std_output(
 ) -> None:
     """
     Save found std primers into a fasta file.
+
+    :param results: List containing the amplified region name and dictionary of detected primers (F and/or R).
+    :type results: list[str, dict]
+    :param output_prefix: Prefix to be used for output files.
+    :type output_prefix: str
+    :param std_primer_dict: Dictionary of standard primers and their sequences.
+    :type std_primer_dict: defaultdict
+    :param merged: Whether the input is merged paired-end or single-end reads. Defaults to False.
+    :type merged: bool
+    :return: Tuple of paths to the output FASTA and summary text files.
+    :rtype: tuple[Path, Path]
     """
 
     with (

--- a/pimento/bin/thresholds.py
+++ b/pimento/bin/thresholds.py
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# used by bin.amplicon_utils.fetch_read_substrings
+# used by bin.pimento_utils.fetch_read_substrings
 MAX_READ_COUNT = 300_000
-# used by bin.amplicon_utils.build_cons_seq
+# used by bin.pimento_utils.build_cons_seq
 CONSENSUS_BASE_THRESHOLD = 0.80
+# used by bin.pimento_utils.primer_regex_query_builder
+STD_PRIMER_ERROR_RATE = 0.1
 
 # used by pimento.standard_primer_strategy
 MIN_STD_PRIMER_THRESHOLD = 0.60

--- a/pimento/pimento_cli.py
+++ b/pimento/pimento_cli.py
@@ -22,6 +22,7 @@ from pimento.bin.thresholds import (
     MIN_STD_PRIMER_THRESHOLD,
     STD_PRIMER_READ_PREFIX_LENGTH,
     MAX_READ_COUNT,
+    STD_PRIMER_ERROR_RATE,
 )
 
 console = Console()
@@ -83,6 +84,13 @@ standard primers, to increase speed. Default value of 300,000.",
     default=MAX_READ_COUNT,
 )
 @click.option(
+    "-e",
+    "--std_primer_error_rate",
+    help="The maximum error rate allowed for standard primers. Default value of 0.1.",
+    type=float,
+    default=STD_PRIMER_ERROR_RATE,
+)
+@click.option(
     "-o", "--output_prefix", required=True, help="Prefix to output file.", type=str
 )
 @click.option(
@@ -107,6 +115,7 @@ def standard_primer_strategy(
     minimum_primer_threshold: float,
     std_primer_read_prefix_length: int,
     max_read_count: int,
+    std_primer_error_rate: float,
     output_prefix: str,
     merged: bool,
     threads: int,
@@ -149,7 +158,7 @@ def standard_primer_strategy(
 
     with console.status("[bold yellow]Loading standard primer library..."):
         std_primer_dict_regex, std_primer_dict, primer_count = parse_std_primers(
-            primers_dir, merged
+            primers_dir, std_primer_error_rate, merged
         )  # Parse std primer library into dictionaries
         console.log(
             "[bold green]Loading standard primer library :white_check_mark:[/bold green]\n"

--- a/pimento/pimento_cli.py
+++ b/pimento/pimento_cli.py
@@ -137,8 +137,16 @@ def standard_primer_strategy(
     :param minimum_primer_threshold: The minimum matching proportion threshold for a primer to be considered.
     The current default value for this threshold is a proportion of 0.60 of reads. Users can customise this value.
     :type minimum_primer_threshold: float
+    :param std_primer_read_prefix_length: Length of read prefix to search for primers.
+    :type std_primer_read_prefix_length: int
+    :param max_read_count: Maximum number of reads to process.
+    :type max_read_count: int
+    :param std_primer_error_rate: The maximum error rate allowed for standard primers.
+    :type std_primer_error_rate: float
     :param output_prefix: The prefix to be used on output files.
     :type output_prefix: str
+    :param merged: Whether the input is merged paired-end or single-end reads.
+    :type merged: bool
     :param threads: Number of threads to use for parallel matching.
     :type threads: int
     """
@@ -305,6 +313,8 @@ def generate_base_conservation_vector(
     :type input_fastq: Path
     :param strand: The strand(s) to perform primer inference for. Values can be either F, R, or FR for both.
     :type strand: str
+    :param max_read_count: Maximum number of reads to process.
+    :type max_read_count: int
     :param output_prefix: The prefix to be used on output files.
     :type output_prefix: str
     :return: TSV file containing the base-conservation vector.
@@ -441,6 +451,8 @@ def choose_primer_cutoff(
     :type input_fastq: Path
     :param primer_cutoffs: TSV file containing the potential cutoff points to consider.
     :type primer_cutoffs: Path
+    :param max_read_count: Maximum number of reads to process.
+    :type max_read_count: int
     :param output_prefix: The prefix to be used on output files.
     :type output_prefix: str
     :return: The output FASTA file containing the inferred primer sequences.
@@ -542,6 +554,8 @@ def primer_cutoff_strategy(
     :type input_fastq: Path
     :param strand: The strand(s) to perform primer inference for. Values can be either F, R, or FR for both.
     :type strand: str
+    :param max_read_count: Maximum number of reads to process.
+    :type max_read_count: int
     :param output_prefix: The prefix to be used on output files.
     :type output_prefix: str
     """

--- a/tests/test_threshold_parameters.py
+++ b/tests/test_threshold_parameters.py
@@ -529,3 +529,88 @@ class TestAutoPipelineThresholds:
         assert mock_choose.called
         choose_call_args = mock_choose.call_args[0]
         assert choose_call_args[2] == custom_max_read_count
+
+
+class TestPrimerRegexQueryBuilder:
+    """Test max_error calculation in primer_regex_query_builder function."""
+
+    def test_max_error_calculation_with_various_parameters(self) -> None:
+        """
+        Test that max_error is calculated correctly as ceil(primer_length * std_primer_error_rate).
+
+        Tests multiple combinations of primer lengths and error rates to ensure the
+        ceiling function is applied correctly.
+        """
+        from pimento.bin.pimento_utils import primer_regex_query_builder
+        import regex
+
+        # Test case 1: primer_length=20, std_primer_error_rate=0.1 -> max_error=2
+        primer_20bp = "A" * 20
+        result = primer_regex_query_builder(primer_20bp, 0.1)
+        # Extract max_error from regex pattern: (.*AAAA...){{e<=2}}
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 2
+        ), f"Expected max_error=2 for 20bp primer with 0.1 error rate, got {max_error}"
+
+        # Test case 2: primer_length=15, std_primer_error_rate=0.1 -> max_error=2 (ceil(1.5)=2)
+        primer_15bp = "A" * 15
+        result = primer_regex_query_builder(primer_15bp, 0.1)
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 2
+        ), f"Expected max_error=2 for 15bp primer with 0.1 error rate, got {max_error}"
+
+        # Test case 3: primer_length=10, std_primer_error_rate=0.1 -> max_error=1 (ceil(1.0)=1)
+        primer_10bp = "A" * 10
+        result = primer_regex_query_builder(primer_10bp, 0.1)
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 1
+        ), f"Expected max_error=1 for 10bp primer with 0.1 error rate, got {max_error}"
+
+        # Test case 4: primer_length=25, std_primer_error_rate=0.2 -> max_error=5 (ceil(5.0)=5)
+        primer_25bp = "A" * 25
+        result = primer_regex_query_builder(primer_25bp, 0.2)
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 5
+        ), f"Expected max_error=5 for 25bp primer with 0.2 error rate, got {max_error}"
+
+        # Test case 5: primer_length=17, std_primer_error_rate=0.15 -> max_error=3 (ceil(2.55)=3)
+        primer_17bp = "A" * 17
+        result = primer_regex_query_builder(primer_17bp, 0.15)
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 3
+        ), f"Expected max_error=3 for 17bp primer with 0.15 error rate, got {max_error}"
+
+        # Test case 6: primer_length=8, std_primer_error_rate=0.1 -> max_error=1 (ceil(0.8)=1)
+        primer_8bp = "A" * 8
+        result = primer_regex_query_builder(primer_8bp, 0.1)
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 1
+        ), f"Expected max_error=1 for 8bp primer with 0.1 error rate, got {max_error}"
+
+        # Test case 7: primer_length=30, std_primer_error_rate=0.05 -> max_error=2 (ceil(1.5)=2)
+        primer_30bp = "A" * 30
+        result = primer_regex_query_builder(primer_30bp, 0.05)
+        match = regex.search(r"\{e<=(\d+)\}", result)
+        assert match is not None
+        max_error = int(match.group(1))
+        assert (
+            max_error == 2
+        ), f"Expected max_error=2 for 30bp primer with 0.05 error rate, got {max_error}"

--- a/tests/test_threshold_parameters.py
+++ b/tests/test_threshold_parameters.py
@@ -31,6 +31,7 @@ from pimento.bin.thresholds import (
     MIN_STD_PRIMER_THRESHOLD,
     STD_PRIMER_READ_PREFIX_LENGTH,
     MAX_READ_COUNT,
+    STD_PRIMER_ERROR_RATE,
 )
 
 
@@ -189,6 +190,57 @@ class TestStandardPrimerThresholds:
         # Fifth positional argument is max_read_count
         assert call_args[4] == custom_max_read_count
         assert call_args[4] != MAX_READ_COUNT
+
+    @patch("pimento.pimento_cli.write_std_output")
+    @patch("pimento.pimento_cli.get_primer_props")
+    @patch("pimento.pimento_cli.parse_std_primers")
+    def test_std_primer_error_rate_custom(
+        self, mock_parse: MagicMock, mock_get_props: MagicMock, mock_write: MagicMock
+    ) -> None:
+        """
+        Test that --std_primer_error_rate parameter overrides STD_PRIMER_ERROR_RATE default.
+
+        Verifies that custom value (0.2) is passed to parse_std_primers() instead of
+        default value (0.1).
+
+        :param mock_parse: Mock for parse_std_primers function.
+        :type mock_parse: MagicMock
+        :param mock_get_props: Mock for get_primer_props function.
+        :type mock_get_props: MagicMock
+        :param mock_write: Mock for write_std_output function.
+        :type mock_write: MagicMock
+        """
+        # Setup mocks
+        mock_parse.return_value = ({}, {}, 0)
+        mock_get_props.return_value = []
+        mock_write.return_value = (Path("test.fasta"), Path("test.txt"))
+
+        runner = CliRunner()
+        custom_error_rate = 0.2
+
+        result = runner.invoke(
+            cli,
+            [
+                "std",
+                "--input_fastq",
+                "tests/fixtures/test.fastq.gz",
+                "--output_prefix",
+                "test_output",
+                "--std_primer_error_rate",
+                str(custom_error_rate),
+                "--merged",
+            ],
+        )
+
+        # Verify command executed successfully
+        assert result.exit_code == 0
+
+        # Verify parse_std_primers was called with custom error rate
+        assert mock_parse.called
+        call_args = mock_parse.call_args[0]
+        # Second positional argument is std_primer_error_rate
+        assert call_args[1] == custom_error_rate
+        assert call_args[1] != STD_PRIMER_ERROR_RATE
 
     @patch("pimento.pimento_cli.write_std_output")
     @patch("pimento.pimento_cli.get_primer_props")

--- a/tests/unit/test_standard_primer_matching.yml
+++ b/tests/unit/test_standard_primer_matching.yml
@@ -23,7 +23,7 @@
 - name: standard_primer_matching test_different_thresholds
   tags:
     - standard_primer_matching
-  command: pimento std -i tests/fixtures/test.fastq.gz  --merged -o sample --minimum_primer_threshold 0.2 --std_primer_read_prefix_length 50 --max_read_count 10
+  command: pimento std -i tests/fixtures/test.fastq.gz  --merged -o sample --minimum_primer_threshold 0.2 --std_primer_read_prefix_length 50 --max_read_count 10 --std_primer_error_rate 0
   files:
     - path: "sample_std_primers.fasta"
       md5sum: f26cdc22a5231d2dbd0831f1f1983dc6


### PR DESCRIPTION
This PR makes two changes to the error rate for standard primer searching:
- Replaces a flat error rate of 2 bases with a percentage of the primer length, with a default of 10% that rounds up (so a primer length of 15 still gives an error rate of 2 bases)
- Makes that error rate customisable similar to tools like cutadapt, using a new parameter `std_primer_error_rate`

Also added missing docstrings and one missing type hint
> [!CAUTION]
> The unit tests were written by Claude, and reviewed by me. 